### PR TITLE
Use absolute URL for Chainlit screenshot

### DIFF
--- a/integrations/chainlit.md
+++ b/integrations/chainlit.md
@@ -18,7 +18,7 @@ logo: /logos/chainlit.png
 
 Chainlit is an open-source Python package that makes it incredibly fast to build, test and share LLM apps. Integrate the Chainlit API in your existing code to spawn a ChatGPT-like interface in minutes. With a simple line of code, you can leverage Chainlit to interact with your agent, visualise intermediary steps, debug them in an advanced prompt playground and share your app to collect human feedback. More info on the [documentation](https://docs.chainlit.io/).
 
-![Screenshot](/images/chainlit-haystack.png)
+![Chainlit screenshot](https://raw.githubusercontent.com/deepset-ai/haystack-integrations/main/images/chainlit-haystack.png)
 
 # Installation
 


### PR DESCRIPTION
The Chainlit screenshot doesn't appear in the [correspondent web page](https://haystack.deepset.ai/integrations/chainlit).

Let's try to use an absolute URL...