### PR TITLE
Change tags to "Model Provider"

### DIFF
--- a/integrations/instructor-embedder.md
+++ b/integrations/instructor-embedder.md
@@ -15,7 +15,7 @@ authors:
         linkedin: varun-mathur-ds
 pypi: https://pypi.org/project/instructor-embedders-haystack/
 repo: https://github.com/deepset-ai/haystack-extras/tree/main/components/instructor-embedders
-type: Custom Node
+type: Model Provider
 report_issue: https://github.com/deepset-ai/haystack-extras/issues
 version: Haystack 2.0
 ---

--- a/integrations/vllm.md
+++ b/integrations/vllm.md
@@ -8,7 +8,7 @@ authors:
       github: LLukas22
 pypi: https://pypi.org/project/vllm-haystack/
 repo: https://github.com/LLukas22/vLLM-haystack-adapter
-type: Custom Node
+type: Model Provider
 report_issue: https://github.com/LLukas22/vLLM-haystack-adapter/issues
 logo: /logos/vllm.png
 ---


### PR DESCRIPTION
Does tagging this as Model Provider make more sense for navigation? In my view it does? Wdyt @masci @bilgeyucel