### PR TITLE
update Cohere model to embed-multilingual-v3.0

### DIFF
--- a/integrations/cohere.md
+++ b/integrations/cohere.md
@@ -93,7 +93,7 @@ Context:
 Question: What's the official language of {{ country }}?
 """
 pipe = Pipeline()
-pipe.add_component("embedder", CohereTextEmbedder(api_key=api_key, model_name="embed-multilingual-v2.0"))
+pipe.add_component("embedder", CohereTextEmbedder(api_key=api_key, model_name="embed-multilingual-v3.0"))
 pipe.add_component("retriever", InMemoryEmbeddingRetriever(document_store=document_store))
 pipe.add_component("prompt_builder", PromptBuilder(template=template))
 pipe.add_component("llm", CohereGenerator(api_key=api_key, model_name="command-light"))


### PR DESCRIPTION
Running this code in order to update the integration docs, I ran into this error:

```
DocumentStoreError: The embedding size of the query should be the same as the embedding size of the Documents. Please make sure that the query has been embedded with the same model as the Documents.
```

Updating the model to v3.0 fixes the error and the code runs as expected. 
