### PR TITLE
bug: Fixed Mismatched Quotes for host

### DIFF
--- a/integrations/weaviate-document-store.md
+++ b/integrations/weaviate-document-store.md
@@ -49,7 +49,7 @@ from haystack import Pipeline
 from haystack.document_stores import WeaviateDocumentStore
 from haystack.nodes import EmbeddingRetriever, MarkdownConverter, PreProcessor
 
-document_store = WeaviateDocumentStore(host='http://localhost",
+document_store = WeaviateDocumentStore(host="http://localhost",
                                        port=8080,
                                        embedding_dim=768)
 converter = MarkdownConverter()


### PR DESCRIPTION
SyntaxError because the interpreter expects the closing quote to match the opening one. To avoid this error, make sure to use the same type of quote for both the opening and closing of the string.