### PR TITLE
add working query pipeline example code to elasticsearch-document-store.md

### DIFF
--- a/integrations/elasticsearch-document-store.md
+++ b/integrations/elasticsearch-document-store.md
@@ -88,7 +88,7 @@ indexing_pipeline.run({
 
 ### Using Elasticsearch in a Query Pipeline
 
-Once you have documents in your `ElasitsearchDocumentStore`, it's ready to be used with with [ElasticsearchEmbeddingRetriever](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/elasticsearch/src/elasticsearch_haystack/embedding_retriever.py) in the retrieval step of any Haystack pipeline such as a Retrieval Augmented Generation (RAG) pipelines. Learn more about [Retrievers](https://docs.haystack.deepset.ai/v2.0/docs/retrievers) to make use of vector search within your LLM pipelines.
+Once you have documents in your `ElasticsearchDocumentStore`, it's ready to be used with with [ElasticsearchEmbeddingRetriever](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/elasticsearch/src/elasticsearch_haystack/embedding_retriever.py) in the retrieval step of any Haystack pipeline such as a Retrieval Augmented Generation (RAG) pipelines. Learn more about [Retrievers](https://docs.haystack.deepset.ai/v2.0/docs/retrievers) to make use of vector search within your LLM pipelines.
 
 ```python
 from elasticsearch_haystack.document_store import ElasticsearchDocumentStore

--- a/integrations/elasticsearch-document-store.md
+++ b/integrations/elasticsearch-document-store.md
@@ -94,17 +94,24 @@ Once you have documents in your `ElasitsearchDocumentStore`, it's ready to be us
 from elasticsearch_haystack.document_store import ElasticsearchDocumentStore
 from haystack.pipeline import Pipeline
 from haystack.components.embedders import SentenceTransformersTextEmbedder 
-from elasticsearch_haystack.embedding_retriever import ElasticsearchEmbeddingRetriever 
+from elasticsearch_haystack.embedding_retriever import ElasticsearchEmbeddingRetriever
 
-document_store = ElasticsearchDocumentStore(host = "http://localhost:9200")
-retriever = ElasticsearchEmbeddingRetriever(document_store)
-text_embedder = SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/multi-qa-mpnet-base-dot-v1")
+model_name_or_path = "sentence-transformers/multi-qa-mpnet-base-dot-v1"
+
+document_store = ElasticsearchDocumentStore(hosts = "http://localhost:9200")
+
+
+retriever = ElasticsearchEmbeddingRetriever(document_store=document_store)
+text_embedder = SentenceTransformersTextEmbedder(model_name_or_path=model_name_or_path)
 
 query_pipeline = Pipeline()
 query_pipeline.add_component("text_embedder", text_embedder)
 query_pipeline.add_component("retriever", retriever)
+query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
 
-query_pipeline.run(query = "historical places in Istanbul")
+result = query_pipeline.run({"text_embedder": {"text": "historical places in Instanbul"}})
+
+print(result)
 ```
 
 ## Haystack 1.x


### PR DESCRIPTION
fixes https://github.com/deepset-ai/haystack-integrations/issues/98

test strategy:
- [x] start up Elasticsearch instance
- [x] run code locally 

output:
```
{'retriever': {'documents': [Document(id=6383dc3ed51fc90c2e45704853a7ad9b14168f4f262ac7a0b65e02c465d0bb1c, content: 'Historic Areas of Istanbul
With its strategic location on the Bosphorus peninsula between the Balkan...', meta: {'file_path': 'filename.txt', 'source_id': 'bb4b4bbec446c13f103bd0ec1777cbb424ae6d2bef355b17a5e299e97e9d4f55'}, score: 0.82134724, embedding: vector of size 1024)]}}
```