### PR TITLE
[Chroma] Remove link to colab notebook

### DIFF
--- a/integrations/chroma-documentstore.md
+++ b/integrations/chroma-documentstore.md
@@ -64,7 +64,7 @@ indexing.run({"converter": {"sources": file_paths}})
 ```
 
 ## Examples
-You can find a code example showing how to use the Document Store and the Retriever under the `example/` folder of [this repo](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/chroma) or in [this Colab](https://colab.research.google.com/drive/1YpDetI8BRbObPDEVdfqUcwhEX9UUXP-m?usp=sharing).
+You can find a code example showing how to use the Document Store and the Retriever under the `example/` folder of [this repo](https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/chroma).
 
 ## License
 


### PR DESCRIPTION
The linked chroma notebook is outdated and won't work. As we already have example code, I suggest we remove the link. Alternative is to update the notebook.