### PR TITLE
Update import path of `Pipeline` in example code

### DIFF
--- a/integrations/assemblyai.md
+++ b/integrations/assemblyai.md
@@ -63,7 +63,7 @@ Following example showcases an indexing pipeline that incorporates `AssemblyAITr
 from haystack.components.writers import DocumentWriter
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
-from haystack.pipeline import Pipeline
+from haystack import Pipeline
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from assemblyai_haystack.transcriber import AssemblyAITranscriber
 

--- a/integrations/elasticsearch-document-store.md
+++ b/integrations/elasticsearch-document-store.md
@@ -59,7 +59,7 @@ For this step, you can use the available [TextFileToDocument](https://docs.hayst
 
 ```python
 from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
-from haystack.pipeline import Pipeline
+from haystack import Pipeline
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.converters import TextFileToDocument
 from haystack.components.preprocessors import DocumentSplitter
@@ -92,7 +92,7 @@ Once you have documents in your `ElasticsearchDocumentStore`, it's ready to be u
 
 ```python
 from haystack_integrations.document_stores.elasticsearch import ElasticsearchDocumentStore
-from haystack.pipeline import Pipeline
+from haystack import Pipeline
 from haystack.components.embedders import SentenceTransformersTextEmbedder 
 from haystack_integrations.components.retrievers.elasticsearch import ElasticsearchEmbeddingRetriever
 

--- a/integrations/pgvector-documentstore.md
+++ b/integrations/pgvector-documentstore.md
@@ -89,7 +89,7 @@ You can retrieve Documents similar to a given query using a simple Pipeline.
 ```python
 from haystack.components.embedders import SentenceTransformersTextEmbedder
 from haystack_integrations.components.retrievers.pgvector import PgvectorEmbeddingRetriever
-from haystack.pipeline import Pipeline
+from haystack import Pipeline
 
 querying = Pipeline()
 querying.add_component("embedder", SentenceTransformersTextEmbedder())


### PR DESCRIPTION
The new beta release breaks the old import `from haystack.pipeline import Pipeline.` I changed it to `from haystack import Pipeline`, which is what we use in all other tutorials too.

Related PRs: https://github.com/deepset-ai/haystack/pull/6973 and https://github.com/deepset-ai/haystack-tutorials/pull/285