### PR TITLE
Use the pre-defined `model` for the model name in Astra DB docs

### DIFF
--- a/integrations/astradb.md
+++ b/integrations/astradb.md
@@ -93,13 +93,13 @@ documents = [Document(content="There are over 7,000 languages spoken around the 
 						Document(content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."),
 						Document(content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.")]
 
-document_embedder = SentenceTransformersDocumentEmbedder(model=model_name_or_path)  
+document_embedder = SentenceTransformersDocumentEmbedder(model=model)  
 document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(documents_with_embeddings.get("documents"))
 query_pipeline = Pipeline()
-query_pipeline.add_component("text_embedder", SentenceTransformersTextEmbedder(model=model_name_or_path))
+query_pipeline.add_component("text_embedder", SentenceTransformersTextEmbedder(model=model))
 query_pipeline.add_component("retriever", AstraEmbeddingRetriever(document_store=document_store))
 query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
 


### PR DESCRIPTION
Fixes a runtime error for that variable not being defined