### PR TITLE
Update Ollama integration tile with an embedder example

### DIFF
--- a/integrations/ollama.md
+++ b/integrations/ollama.md
@@ -175,6 +175,7 @@ docker run -d -p 11434:11434 --name ollama ollama/ollama:latest
 docker exec ollama ollama pull nomic-embed-text
 ```
 
+Below is an example that uses both `OllamaDocumentEmbedder` and `OllamaTextEmbedder`.
 ```python
 from haystack import Document, Pipeline
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever

--- a/integrations/ollama.md
+++ b/integrations/ollama.md
@@ -165,6 +165,7 @@ Natural Language Processing (NLP) is a complex field with many different tools a
 
 - `OllamaDocumentEmbedder` helps compute embeddings for a list of Documents and updates each Document's embedding field with its embedding vector.
 - `OllamaTextEmbedder` computes the embeddings of a particular string.
+
 Both `OllamaTextEmbedder` and `OllamaDocumentEmbedder` use embedding models compatible with the Ollama Library.
 
 To run the below example, use the below command to serve a `nomic-embed-text` model from Ollama:

--- a/integrations/ollama.md
+++ b/integrations/ollama.md
@@ -163,8 +163,8 @@ Natural Language Processing (NLP) is a complex field with many different tools a
 ```
 #### Embedders
 
-**OllamaDocumentEmbedder** can be used to compute the embeddings of a list of Documents and update the embedding field of each Document with the embedding vector.
-**OllamaTextEmbedder** computes the embeddings of a particular string.
+- `OllamaDocumentEmbedder` helps compute embeddings for a list of Documents and updates each Document's embedding field with its embedding vector.
+- `OllamaTextEmbedder` computes the embeddings of a particular string.
 Both `OllamaTextEmbedder` and `OllamaDocumentEmbedder` use embedding models compatible with the Ollama Library.
 
 To run the below example, use the below command to serve a `nomic-embed-text` model from Ollama:


### PR DESCRIPTION
Updated the Ollama integration tile with an example for embedder.
Fixes https://github.com/deepset-ai/haystack-core-integrations/issues/652

Related issue: https://github.com/deepset-ai/haystack-core-integrations/issues/651