### PR TITLE
docs: fix title of code example for Langfuse integration

### DIFF
--- a/integrations/langfuse.md
+++ b/integrations/langfuse.md
@@ -128,7 +128,7 @@ response = pipeline.run({"text_embedder": {"text": question}, "prompt_builder": 
 
 Once you've run these code samples, you can also [use the Langfuse dashboard to see and interact with traces](https://langfuse.com/docs/demo).
 
-### Use `LangfuseConnector` in a RAG pipeline:
+### Use `LangfuseConnector` in a pipeline with `OpenAIChatGenerator` and `ChatPromptBuilder`:
 
 ```python
 from haystack import Pipeline

--- a/integrations/langfuse.md
+++ b/integrations/langfuse.md
@@ -103,7 +103,7 @@ def get_pipeline(document_store: InMemoryDocumentStore):
     )
     basic_rag_pipeline.add_component("retriever", retriever)
     basic_rag_pipeline.add_component("prompt_builder", prompt_builder)
-    basic_rag_pipeline.add_component("llm", OpenAIGenerator(model="gpt-3.5-turbo", generation_kwargs={"n": 2}))
+    basic_rag_pipeline.add_component("llm", OpenAIGenerator(generation_kwargs={"n": 2}))
 
     # Now, connect the components to each other
     # NOTE: the tracer component doesn't need to be connected to anything in order to work
@@ -123,7 +123,7 @@ document_store.write_documents(docs_with_embeddings)
 pipeline = get_pipeline(document_store)
 question = "What does Rhodes Statue look like?"
 response = pipeline.run({"text_embedder": {"text": question}, "prompt_builder": {"question": question}})
-# {'tracer': {'name': 'Basic RAG Pipeline', 'trace_url': 'https://cloud.langfuse.com/trace/3d52b8cc-87b6-4977-8927-5e9f3ff5b1cb'}, 'llm': {'replies': ['The Rhodes Statue was described as being about 105 feet tall, with iron tie bars and brass plates forming the skin. It was built on a white marble pedestal near the Rhodes harbour entrance. The statue was filled with stone blocks as construction progressed.', 'The Rhodes Statue was described as being about 32 meters (105 feet) tall, built with iron tie bars, brass plates for skin, and filled with stone blocks. It stood on a 15-meter-high white marble pedestal near the Rhodes harbor entrance.'], 'meta': [{'model': 'gpt-3.5-turbo-0125', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 100, 'prompt_tokens': 453, 'total_tokens': 553}}, {'model': 'gpt-3.5-turbo-0125', 'index': 1, 'finish_reason': 'stop', 'usage': {'completion_tokens': 100, 'prompt_tokens': 453, 'total_tokens': 553}}]}}
+# {'tracer': {'name': 'Basic RAG Pipeline', 'trace_url': 'https://cloud.langfuse.com/trace/3d52b8cc-87b6-4977-8927-5e9f3ff5b1cb'}, 'llm': {'replies': ['The Rhodes Statue was described as being about 105 feet tall, with iron tie bars and brass plates forming the skin. It was built on a white marble pedestal near the Rhodes harbour entrance. The statue was filled with stone blocks as construction progressed.', 'The Rhodes Statue was described as being about 32 meters (105 feet) tall, built with iron tie bars, brass plates for skin, and filled with stone blocks. It stood on a 15-meter-high white marble pedestal near the Rhodes harbor entrance.'], 'meta': [{'model': 'gpt-4o-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 100, 'prompt_tokens': 453, 'total_tokens': 553}}, {'model': 'gpt-4o-mini', 'index': 1, 'finish_reason': 'stop', 'usage': {'completion_tokens': 100, 'prompt_tokens': 453, 'total_tokens': 553}}]}}
 ```
 
 Once you've run these code samples, you can also [use the Langfuse dashboard to see and interact with traces](https://langfuse.com/docs/demo).
@@ -140,7 +140,7 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 pipe = Pipeline()
 pipe.add_component("tracer", LangfuseConnector("Chat example"))
 pipe.add_component("prompt_builder", ChatPromptBuilder())
-pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+pipe.add_component("llm", OpenAIChatGenerator())
 
 pipe.connect("prompt_builder.prompt", "llm.messages")
 messages = [
@@ -153,7 +153,7 @@ response = pipe.run(
 )
 print(response["llm"]["replies"][0])
 print(response["tracer"]["trace_url"])
-# ChatMessage(content='Berlin ist die Hauptstadt von Deutschland und zugleich eines der bekanntesten kulturellen Zentren Europas. Die Stadt hat eine faszinierende Geschichte, die bis in die Zeiten des Zweiten Weltkriegs und des Kalten Krieges zurückreicht. Heute ist Berlin für seine vielfältige Kunst- und Musikszene, seine historischen Stätten wie das Brandenburger Tor und die Berliner Mauer sowie seine lebendige Street-Food-Kultur bekannt. Berlin ist auch für seine grünen Parks und Seen beliebt, die den Bewohnern und Besuchern Raum für Erholung bieten.', role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-3.5-turbo-0125', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 137, 'prompt_tokens': 29, 'total_tokens': 166}})
+# ChatMessage(content='Berlin ist die Hauptstadt von Deutschland und zugleich eines der bekanntesten kulturellen Zentren Europas. Die Stadt hat eine faszinierende Geschichte, die bis in die Zeiten des Zweiten Weltkriegs und des Kalten Krieges zurückreicht. Heute ist Berlin für seine vielfältige Kunst- und Musikszene, seine historischen Stätten wie das Brandenburger Tor und die Berliner Mauer sowie seine lebendige Street-Food-Kultur bekannt. Berlin ist auch für seine grünen Parks und Seen beliebt, die den Bewohnern und Besuchern Raum für Erholung bieten.', role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-4o-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 137, 'prompt_tokens': 29, 'total_tokens': 166}})
 # https://cloud.langfuse.com/trace/YOUR_UNIQUE_IDENTIFYING_STRING
 ```
 


### PR DESCRIPTION
- Just changing the title of a code example from RAG pipeline to pipeline with ChatGenerator, ChatPromptBuilder because that pipeline doesn't contain a retriever so it's not RAG.
- Remove deprecated `gpt-3.5.-turbo` model and use the default, which is `gpt-4o-mini` instead
