### PR TITLE
update docker image for pgvector

### DIFF
--- a/integrations/pgvector-documentstore.md
+++ b/integrations/pgvector-documentstore.md
@@ -35,7 +35,7 @@ toc: true
 
 To quickly set up a PostgreSQL database with pgvector, you can use Docker:
 ```bash
-docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres ankane/pgvector
+docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres pgvector/pgvector:pg17
 ```
 
 For more information on how to install pgvector, visit the [pgvector GitHub repository](https://github.com/pgvector/pgvector).


### PR DESCRIPTION
In the past, pgvector used the `ankane/pgvector`docker image.
Now it needs `pgvector/pgvector` (with a mandatory tag; latest does not exist).

I've already updated docs and I'll do the same for examples in the core integrations repo.