### PR TITLE
fix `WeaveConnector` import

### DIFF
--- a/integrations/weights-and-bias-tracer.md
+++ b/integrations/weights-and-bias-tracer.md
@@ -59,7 +59,7 @@ from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 
-from haystack_integrations.components.connectors import WeaveConnector
+from haystack_integrations.components.connectors.weave import WeaveConnector
 
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 messages = [


### PR DESCRIPTION
In https://github.com/deepset-ai/haystack-core-integrations/pull/2038,
I changed the location of `WeaveConnector` for consistency with other integrations.

Since this is a breaking change, I released a new major version (1.0.0).

In this PR, I am fixing the import.