### PR TITLE
[FEAT] Added valyu integration

### DIFF
--- a/integrations/valyu.md
+++ b/integrations/valyu.md
@@ -8,7 +8,7 @@ authors:
       github: valyu-network
 pypi: https://pypi.org/project/valyu-search-haystack
 repo: https://github.com/valyu-network/valyu-search-haystack
-type: Search & Content Extraction
+type: Search & Extraction
 report_issue: https://github.com/valyu-network/valyu-search-haystack/issues
 version: Haystack 2.0
 toc: true


### PR DESCRIPTION
Adding Valyu integration docs for the [valyu-search-haystack](https://pypi.org/project/valyu-search-haystack/) integration that allows agents to:
-  Search over the web and proprietary sources like SEC filings, market data, patents and scientific research.
- Extract contents of web pages from their urls