### PR TITLE
Add Azure Document Intelligence integration

### DIFF
--- a/integrations/azure-doc-intelligence.md
+++ b/integrations/azure-doc-intelligence.md
@@ -24,7 +24,7 @@ toc: true
 
 ## Overview
 
-`AzureDocumentIntelligenceConverter` provides an integration of [Azure Document Intelligence](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/) (formerly Form Recognizer) with [Haystack](https://haystack.deepset.ai/) by [deepset](https://www.deepset.ai).
+[`AzureDocumentIntelligenceConverter`](https://docs.haystack.deepset.ai/docs/azureocrdocumentconverter) provides an integration of [Azure Document Intelligence](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/) (formerly Form Recognizer) with [Haystack](https://haystack.deepset.ai/) by [deepset](https://www.deepset.ai).
 
 This component uses Azure's Document Intelligence service to convert various file formats into Haystack Documents with markdown content. It supports advanced document analysis including layout detection, table extraction, and structured content recognition.
 


### PR DESCRIPTION
part of https://github.com/deepset-ai/haystack-core-integrations/issues/2764 as follow up to https://github.com/deepset-ai/haystack-core-integrations/pull/2717 by @vblagoje 

Instead of the general Azure logo, we could use a logo for azure document intelligence instead. However, it seems to be rarely used. I'd suggest we use the general Azure logo
<img width="300" height="157" alt="image" src="https://github.com/user-attachments/assets/a01c0e22-e203-4a35-b2ac-402fa5d430ce" />
