### PR TITLE
Remove warm-up calls for FastEmbed components

### DIFF
--- a/integrations/fastembed.md
+++ b/integrations/fastembed.md
@@ -70,7 +70,6 @@ documents = [
 ]
 
 document_embedder = FastembedDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)
 
@@ -113,7 +112,6 @@ documents = [
 ]
 
 sparse_document_embedder = FastembedSparseDocumentEmbedder()
-sparse_document_embedder.warm_up()
 documents_with_sparse_embeddings = sparse_document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_sparse_embeddings)
 
@@ -150,7 +148,6 @@ documents = [
 ]
 
 document_embedder = FastembedDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)
 


### PR DESCRIPTION
In https://github.com/deepset-ai/haystack-core-integrations/pull/2678, we removed the need to explicitly call `warm_up` for FastEmbed components. I adapted the examples to reflect this change and make them easier.