### PR TITLE
docs: add FastembedColbertRanker to fastembed integration page

### DIFF
--- a/integrations/fastembed.md
+++ b/integrations/fastembed.md
@@ -51,7 +51,7 @@ The `fastembed-haystack` integrations provides the following components:
 	- `FastembedSparseDocumentEmbedder`: enriches documents with sparse embeddings (used in indexing pipelines).
 - Rankers:
 	- `FastembedRanker`: ranks documents based on a query using cross-encoder models (used in query/RAG pipelines after the retrieval).
-	- `FastembedColbertRanker`: ranks documents using ColBERT late-interaction (MaxSim) scoring (used in query/RAG pipelines after the retrieval).
+	- `FastembedLateInteractionRanker`: ranks documents using ColBERT late-interaction (MaxSim) scoring (used in query/RAG pipelines after the retrieval).
   
 ### Example with dense embeddings
 
@@ -163,9 +163,9 @@ query_pipeline.connect("retriever.documents", "ranker.documents")
 result = query_pipeline.run({"text_embedder": {"text": query}, "ranker": { "query" : query }})
 ```
 
-### Example with ColBERT ranker
+### Example with Late Interaction ranker
 
-`FastembedColbertRanker` uses ColBERT late-interaction scoring: the query and documents are encoded independently into token-level embeddings, and a MaxSim score is computed for each document. This offers stronger ranking quality than cross-encoders on many tasks while remaining efficient.
+`FastembedLateInteractionRanker` uses ColBERT late-interaction scoring: the query and documents are encoded independently into token-level embeddings, and a MaxSim score is computed for each document. This offers stronger ranking quality than cross-encoders on many tasks while remaining efficient.
 
 > **Note:** ColBERT scores are unnormalized sums. They are meaningful for ranking within a single query but should not be compared across queries.
 
@@ -174,7 +174,7 @@ from haystack import Document, Pipeline
 from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack_integrations.components.embedders.fastembed import FastembedDocumentEmbedder, FastembedTextEmbedder
-from haystack_integrations.components.rankers.fastembed import FastembedColbertRanker
+from haystack_integrations.components.rankers.fastembed import FastembedLateInteractionRanker
 
 document_store = InMemoryDocumentStore(embedding_similarity_function="cosine")
 
@@ -194,7 +194,7 @@ document_store.write_documents(documents_with_embeddings)
 query_pipeline = Pipeline()
 query_pipeline.add_component("text_embedder", FastembedTextEmbedder())
 query_pipeline.add_component("retriever", InMemoryEmbeddingRetriever(document_store=document_store, top_k=4))
-query_pipeline.add_component("ranker", FastembedColbertRanker(model_name="colbert-ir/colbertv2.0", top_k=2))
+query_pipeline.add_component("ranker", FastembedLateInteractionRanker(model_name="colbert-ir/colbertv2.0", top_k=2))
 query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
 query_pipeline.connect("retriever.documents", "ranker.documents")
 

--- a/integrations/fastembed.md
+++ b/integrations/fastembed.md
@@ -167,7 +167,7 @@ result = query_pipeline.run({"text_embedder": {"text": query}, "ranker": { "quer
 
 `FastembedColbertRanker` uses ColBERT late-interaction scoring: the query and documents are encoded independently into token-level embeddings, and a MaxSim score is computed for each document. This offers stronger ranking quality than cross-encoders on many tasks while remaining efficient.
 
-> **Note:** ColBERT scores are unnormalized sums (typically ~3–30). They are meaningful for ranking within a single query but should not be compared across queries.
+> **Note:** ColBERT scores are unnormalized sums. They are meaningful for ranking within a single query but should not be compared across queries.
 
 ```python
 from haystack import Document, Pipeline

--- a/integrations/fastembed.md
+++ b/integrations/fastembed.md
@@ -49,8 +49,9 @@ The `fastembed-haystack` integrations provides the following components:
 	- `FastembedDocumentEmbedder`: enriches documents with dense embeddings (used in indexing pipelines).
 	- `FastembedSparseTextEmbedder`: creates a sparse embedding for text (used in query/RAG pipelines).
 	- `FastembedSparseDocumentEmbedder`: enriches documents with sparse embeddings (used in indexing pipelines).
-- Ranker:
-	- `FastembedRanker`: ranks documents based on a query (used in query/RAG pipelines after the retrieval).
+- Rankers:
+	- `FastembedRanker`: ranks documents based on a query using cross-encoder models (used in query/RAG pipelines after the retrieval).
+	- `FastembedColbertRanker`: ranks documents using ColBERT late-interaction (MaxSim) scoring (used in query/RAG pipelines after the retrieval).
   
 ### Example with dense embeddings
 
@@ -160,6 +161,44 @@ query_pipeline.connect("retriever.documents", "ranker.documents")
 
 
 result = query_pipeline.run({"text_embedder": {"text": query}, "ranker": { "query" : query }})
+```
+
+### Example with ColBERT ranker
+
+`FastembedColbertRanker` uses ColBERT late-interaction scoring: the query and documents are encoded independently into token-level embeddings, and a MaxSim score is computed for each document. This offers stronger ranking quality than cross-encoders on many tasks while remaining efficient.
+
+> **Note:** ColBERT scores are unnormalized sums (typically ~3–30). They are meaningful for ranking within a single query but should not be compared across queries.
+
+```python
+from haystack import Document, Pipeline
+from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.components.embedders.fastembed import FastembedDocumentEmbedder, FastembedTextEmbedder
+from haystack_integrations.components.rankers.fastembed import FastembedColbertRanker
+
+document_store = InMemoryDocumentStore(embedding_similarity_function="cosine")
+
+query = "Who supports fastembed?"
+
+documents = [
+    Document(content="My name is Wolfgang and I live in Berlin"),
+    Document(content="I saw a black horse running"),
+    Document(content="Germany has many big cities"),
+    Document(content="fastembed is supported by and maintained by Qdrant."),
+]
+
+document_embedder = FastembedDocumentEmbedder()
+documents_with_embeddings = document_embedder.run(documents)["documents"]
+document_store.write_documents(documents_with_embeddings)
+
+query_pipeline = Pipeline()
+query_pipeline.add_component("text_embedder", FastembedTextEmbedder())
+query_pipeline.add_component("retriever", InMemoryEmbeddingRetriever(document_store=document_store, top_k=4))
+query_pipeline.add_component("ranker", FastembedColbertRanker(model_name="colbert-ir/colbertv2.0", top_k=2))
+query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
+query_pipeline.connect("retriever.documents", "ranker.documents")
+
+result = query_pipeline.run({"text_embedder": {"text": query}, "ranker": {"query": query}})
 ```
 
 ### License


### PR DESCRIPTION
## Summary

Updates the fastembed integration page to include the new `FastembedColbertRanker` component from deepset-ai/haystack-core-integrations#3135.

- Added `FastembedColbertRanker` to the components list alongside `FastembedRanker`
- Added a new "Example with ColBERT ranker" section with a working pipeline code snippet
- Added a note on unnormalized ColBERT scores

## Related
- deepset-ai/haystack-core-integrations#3135 — the PR that adds the component
- deepset-ai/haystack#11092 — new dedicated doc page for the component

🤖 Generated with [Claude Code](https://claude.com/claude-code)