### PR TITLE
Add Future AGI integration

### DIFF
--- a/integrations/future-agi.md
+++ b/integrations/future-agi.md
@@ -1,0 +1,137 @@
+---
+layout: integration
+name: Future AGI
+description: OpenTelemetry tracing and evaluation for Haystack pipelines via traceAI.
+authors:
+    - name: Future AGI
+      socials:
+        github: future-agi
+        linkedin: https://www.linkedin.com/company/future-agi
+pypi: https://pypi.org/project/traceAI-haystack/
+repo: https://github.com/future-agi/traceAI/tree/main/python/frameworks/haystack
+type: Monitoring Tool
+report_issue: https://github.com/future-agi/traceAI/issues
+version: Haystack 2.0
+toc: true
+---
+### **Table of Contents**
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+
+## Overview
+
+[Future AGI](https://futureagi.com) is an open-source AI tracing and evaluation platform built on OpenTelemetry. The `traceAI-haystack` package auto-instruments Haystack pipelines and exports spans to any OTLP-compatible backend (Future AGI, Jaeger, Datadog, etc.).
+
+Once registered, every component run, generator call, retriever query, and pipeline execution is captured as a structured OpenTelemetry span — no per-component wiring required.
+
+### Features
+
+- One-line instrumentation of Haystack pipelines via `HaystackInstrumentor`
+- Standard OpenTelemetry GenAI semantic conventions (prompts, completions, token usage, tool calls)
+- Works with any OTLP-compatible backend
+- Integrates with the Future AGI evaluation suite for online and offline evals
+
+To use Future AGI as the backend, [sign up at app.futureagi.com](https://app.futureagi.com) and grab your `FI_API_KEY` and `FI_SECRET_KEY`. See the [full integration guide](https://docs.futureagi.com/docs/integrations/traceai/haystack) for details.
+
+## Installation
+
+```bash
+pip install traceAI-haystack
+```
+
+For the example pipeline below, you also need:
+
+```bash
+pip install haystack-ai trafilatura
+```
+
+## Usage
+
+### Components
+
+This integration introduces one component:
+
+- The `HaystackInstrumentor`: registers OpenTelemetry instrumentation on Haystack's `Pipeline.run`, `Component.run`, and generator/retriever execution paths. Once `instrument()` is called, every Haystack pipeline run produces a trace automatically.
+
+  Set the `FI_API_KEY` and `FI_SECRET_KEY` environment variables to authenticate with Future AGI. These code examples also require an [`OPENAI_API_KEY`](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key). Haystack is model-agnostic; swap the generator for any provider you prefer.
+
+### Set environment variables
+
+```python
+import os
+
+os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
+os.environ["FI_API_KEY"] = "your-futureagi-api-key"
+os.environ["FI_SECRET_KEY"] = "your-futureagi-secret-key"
+```
+
+### Register the tracer provider
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="haystack_project",
+)
+```
+
+### Instrument Haystack
+
+```python
+from traceai_haystack import HaystackInstrumentor
+
+HaystackInstrumentor().instrument(tracer_provider=trace_provider)
+```
+
+### Run a Haystack pipeline
+
+```python
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.converters import HTMLToDocument
+from haystack.components.fetchers import LinkContentFetcher
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+fetcher = LinkContentFetcher()
+converter = HTMLToDocument()
+prompt_builder = ChatPromptBuilder(
+    template=[
+        ChatMessage.from_user(
+            "Answer the question based on the following context.\n"
+            "Context: {{ documents[0].content }}\n"
+            "Question: {{ query }}"
+        )
+    ]
+)
+generator = OpenAIChatGenerator(model="gpt-4o-mini")
+
+pipeline = Pipeline()
+pipeline.add_component("fetcher", fetcher)
+pipeline.add_component("converter", converter)
+pipeline.add_component("prompt_builder", prompt_builder)
+pipeline.add_component("generator", generator)
+
+pipeline.connect("fetcher.streams", "converter.sources")
+pipeline.connect("converter.documents", "prompt_builder.documents")
+pipeline.connect("prompt_builder.prompt", "generator.messages")
+
+result = pipeline.run(
+    {
+        "fetcher": {"urls": ["https://haystack.deepset.ai/"]},
+        "prompt_builder": {"query": "What is Haystack?"},
+    }
+)
+
+print(result["generator"]["replies"][0].text)
+```
+
+The pipeline run, every component, the LLM call, and token usage are captured as a single trace.
+
+### License
+
+`traceAI-haystack` is released under the [MIT License](https://github.com/future-agi/traceAI/blob/main/LICENSE).


### PR DESCRIPTION
## Overview

Adds [Future AGI](https://futureagi.com) as a Haystack integration (Monitoring Tool).

Future AGI is an open-source AI tracing and evaluation platform built on OpenTelemetry. The [`traceAI-haystack`](https://pypi.org/project/traceAI-haystack/) package auto-instruments Haystack pipelines and exports spans to any OTLP-compatible backend (Future AGI, Jaeger, Datadog, etc.). One call to `HaystackInstrumentor().instrument(...)` covers `Pipeline.run`, every component run, generators, and retrievers.

## What's included

- New file: `integrations/future-agi.md`
- Frontmatter follows the [draft-integration template](https://github.com/deepset-ai/haystack-integrations/blob/main/draft-integration.md): `layout`, `name`, `description`, `authors`, `pypi`, `repo`, `report_issue`, `type: Monitoring Tool`, `version: Haystack 2.0`, `toc: true`
- Body contains Overview, Installation, Usage (with environment variables, tracer registration, instrumentation, and a runnable Haystack 2 pipeline using `LinkContentFetcher` → `HTMLToDocument` → `ChatPromptBuilder` → `OpenAIChatGenerator`), and License sections

## Verification

The pipeline example was executed end-to-end against the published `traceAI-haystack` and `haystack-ai==2.28.0`. The pipeline ran, the LLM call returned a real answer about Haystack, and spans flushed to the Future AGI OTLP endpoint without error.

## Links

- PyPI: https://pypi.org/project/traceAI-haystack/
- Source: https://github.com/future-agi/traceAI/tree/main/python/frameworks/haystack
- Full integration guide: https://docs.futureagi.com/docs/integrations/traceai/haystack

This PR was prepared with the help of an AI coding assistant (Claude Code); the example code was verified by execution against the published package.