### PR TITLE
feat: add PR preview workflow for integration pages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Preview
     permissions:
+      issues: write
       pull-requests: write
-
     steps:
       - name: Trigger Vercel preview build
         id: deploy
@@ -24,25 +24,30 @@ jobs:
           INTEGRATIONS_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
           INTEGRATIONS_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
+          payload=$(jq -n \
+            --arg name "haystack-home" \
+            --arg project "$VERCEL_PROJECT_ID" \
+            --arg repoId "$HAYSTACK_HOME_REPO_ID" \
+            --arg ref "main" \
+            --arg integrations_repo "$INTEGRATIONS_REPO" \
+            --arg integrations_branch "$INTEGRATIONS_BRANCH" \
+            '{
+              name: $name,
+              project: $project,
+              gitSource: {type: "github", repoId: $repoId, ref: $ref},
+              target: "preview",
+              env: [
+                {key: "INTEGRATIONS_REPO", value: $integrations_repo, type: "plain"},
+                {key: "INTEGRATIONS_BRANCH", value: $integrations_branch, type: "plain"}
+              ]
+            }')
           RESPONSE=$(curl -sf -X POST \
             "https://api.vercel.com/v13/deployments?teamId=$VERCEL_TEAM_ID" \
             -H "Authorization: Bearer $VERCEL_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"name\": \"haystack-home\",
-              \"project\": \"$VERCEL_PROJECT_ID\",
-              \"gitSource\": {
-                \"type\": \"github\",
-                \"repoId\": \"$HAYSTACK_HOME_REPO_ID\",
-                \"ref\": \"main\"
-              },
-              \"target\": \"preview\",
-              \"env\": [
-                {\"key\": \"INTEGRATIONS_REPO\", \"value\": \"$INTEGRATIONS_REPO\", \"type\": \"plain\"},
-                {\"key\": \"INTEGRATIONS_BRANCH\", \"value\": \"$INTEGRATIONS_BRANCH\", \"type\": \"plain\"}
-              ]
-            }")
-          echo "url=$(echo $RESPONSE | jq -r '.url')" >> $GITHUB_OUTPUT
+            -d "$payload")
+          url=$(echo "$RESPONSE" | jq -er '.url')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ jobs:
           echo "url=$(echo $RESPONSE | jq -r '.url')" >> $GITHUB_OUTPUT
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const url = '${{ steps.deploy.outputs.url }}';

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    environment: preview
+    environment: Preview
     permissions:
       pull-requests: write
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,82 @@
+name: Preview integration page
+
+on:
+  pull_request_target:
+    paths:
+      - 'integrations/**'
+      - 'logos/**'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    environment: preview
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Trigger Vercel preview build
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          HAYSTACK_HOME_REPO_ID: ${{ secrets.HAYSTACK_HOME_REPO_ID }}
+          INTEGRATIONS_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          INTEGRATIONS_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          RESPONSE=$(curl -sf -X POST \
+            "https://api.vercel.com/v13/deployments?teamId=$VERCEL_TEAM_ID" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"name\": \"haystack-home\",
+              \"project\": \"$VERCEL_PROJECT_ID\",
+              \"gitSource\": {
+                \"type\": \"github\",
+                \"repoId\": \"$HAYSTACK_HOME_REPO_ID\",
+                \"ref\": \"main\"
+              },
+              \"target\": \"preview\",
+              \"env\": [
+                {\"key\": \"INTEGRATIONS_REPO\", \"value\": \"$INTEGRATIONS_REPO\", \"type\": \"plain\"},
+                {\"key\": \"INTEGRATIONS_BRANCH\", \"value\": \"$INTEGRATIONS_BRANCH\", \"type\": \"plain\"}
+              ]
+            }")
+          echo "url=$(echo $RESPONSE | jq -r '.url')" >> $GITHUB_OUTPUT
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            const branch = '${{ github.event.pull_request.head.ref }}';
+            const body = [
+              '### Preview deployment',
+              '',
+              'Vercel is building the preview. Once ready:',
+              `**[View integrations on preview site](https://${url}/integrations/)**`,
+              '',
+              `*Built from \`${branch}\` @ ${{ github.event.pull_request.head.repo.full_name }}*`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('### Preview deployment'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
Implement #465 

Triggers a haystack-home Vercel preview build on PRs touching integrations/ or logos/, passing the PR branch (and fork repo URL) via env vars so the preview reflects the proposed changes.

Gated behind a GitHub Environment with required reviewer approval to prevent untrusted fork PRs from accessing secrets.