### PR TITLE
fix: remove invalid target from Vercel deployments API call

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,7 +35,6 @@ jobs:
               name: $name,
               project: $project,
               gitSource: {type: "github", repoId: $repoId, ref: $ref},
-              target: "preview",
               env: {INTEGRATIONS_REPO: $integrations_repo, INTEGRATIONS_BRANCH: $integrations_branch}
             }')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \


### PR DESCRIPTION
Vercel rejects `target: "preview"` — valid values are `production`, `staging`, or custom. Omitting it defaults to a preview deployment.