### PR TITLE
Add EmpirioLabs integration

### DIFF
--- a/integrations/empiriolabs.md
+++ b/integrations/empiriolabs.md
@@ -1,0 +1,92 @@
+---
+layout: integration
+name: EmpirioLabs
+description: Use open and proprietary models served by EmpirioLabs
+authors:
+    - name: EmpirioLabs Team
+      socials:
+        github: EmpirioLabs-ai
+pypi: https://pypi.org/project/haystack-ai/
+repo: https://github.com/deepset-ai/haystack
+type: Model Provider
+report_issue: https://github.com/deepset-ai/haystack/issues
+logo: /logos/empiriolabs.svg
+version: Haystack 2.0
+toc: true
+---
+
+### **Table of Contents**
+
+- [Overview](#overview)
+- [Usage](#usage)
+
+## Overview
+
+**EmpirioLabs** is a multi-model API platform that hosts open and proprietary models (Qwen, DeepSeek, GLM, Kimi, MiniMax, Gemma, and more) behind one OpenAI-compatible API with pay-as-you-go pricing.
+
+To start using EmpirioLabs, create an API key in the [EmpirioLabs dashboard](https://platform.empiriolabs.ai/dashboard/api-keys). The full model catalog with per-model context windows and pricing is at [empiriolabs.ai/models](https://empiriolabs.ai/models).
+
+## Usage
+
+The EmpirioLabs API is OpenAI compatible, making it easy to use in Haystack via the OpenAI Generators and Embedders.
+
+### Using `ChatGenerator`
+
+Here's an example of chatting with a model served via EmpirioLabs using the `OpenAIChatGenerator`.
+You need to set the environment variable `EMPIRIOLABS_API_KEY` and choose a model from the [catalog](https://empiriolabs.ai/models).
+
+```python
+import os
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+from haystack.utils import Secret
+
+os.environ["EMPIRIOLABS_API_KEY"] = "YOUR_EMPIRIOLABS_API_KEY"
+
+generator = OpenAIChatGenerator(
+    api_key=Secret.from_env_var("EMPIRIOLABS_API_KEY"),
+    api_base_url="https://api.empiriolabs.ai/v1",
+    model="qwen3-7-plus",
+)
+result = generator.run([ChatMessage.from_user("What are the main components of a RAG pipeline?")])
+print(result["replies"][0].text)
+```
+
+### Using `Generator`
+
+EmpirioLabs also works with the plain `OpenAIGenerator` for prompt-in, text-out generation:
+
+```python
+import os
+from haystack.components.generators import OpenAIGenerator
+from haystack.utils import Secret
+
+os.environ["EMPIRIOLABS_API_KEY"] = "YOUR_EMPIRIOLABS_API_KEY"
+
+generator = OpenAIGenerator(
+    api_key=Secret.from_env_var("EMPIRIOLABS_API_KEY"),
+    api_base_url="https://api.empiriolabs.ai/v1",
+    model="qwen3-7-plus",
+)
+result = generator.run("Explain retrieval augmented generation in one paragraph.")
+print(result["replies"][0])
+```
+
+### Using `TextEmbedder`
+
+EmpirioLabs serves OpenAI-compatible embedding models too, so the OpenAI Embedders work the same way:
+
+```python
+import os
+from haystack.components.embedders import OpenAITextEmbedder
+from haystack.utils import Secret
+
+os.environ["EMPIRIOLABS_API_KEY"] = "YOUR_EMPIRIOLABS_API_KEY"
+
+embedder = OpenAITextEmbedder(
+    api_key=Secret.from_env_var("EMPIRIOLABS_API_KEY"),
+    api_base_url="https://api.empiriolabs.ai/v1",
+    model="text-embedding-v4",
+)
+print(embedder.run("The quick brown fox jumped over the lazy dog")["embedding"][:5])
+```

--- a/integrations/empiriolabs.md
+++ b/integrations/empiriolabs.md
@@ -52,26 +52,6 @@ result = generator.run([ChatMessage.from_user("What are the main components of a
 print(result["replies"][0].text)
 ```
 
-### Using `Generator`
-
-EmpirioLabs also works with the plain `OpenAIGenerator` for prompt-in, text-out generation:
-
-```python
-import os
-from haystack.components.generators import OpenAIGenerator
-from haystack.utils import Secret
-
-os.environ["EMPIRIOLABS_API_KEY"] = "YOUR_EMPIRIOLABS_API_KEY"
-
-generator = OpenAIGenerator(
-    api_key=Secret.from_env_var("EMPIRIOLABS_API_KEY"),
-    api_base_url="https://api.empiriolabs.ai/v1",
-    model="qwen3-7-plus",
-)
-result = generator.run("Explain retrieval augmented generation in one paragraph.")
-print(result["replies"][0])
-```
-
 ### Using `TextEmbedder`
 
 EmpirioLabs serves OpenAI-compatible embedding models too, so the OpenAI Embedders work the same way:

--- a/logos/empiriolabs.svg
+++ b/logos/empiriolabs.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <defs>
+    <linearGradient id="lobe-icons-empiriolabs-fill" x1="50%" x2="60%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#7AD7F2"/>
+      <stop offset="48%" stop-color="#1186F5"/>
+      <stop offset="100%" stop-color="#0A2E8C"/>
+    </linearGradient>
+  </defs>
+  <path d="M11.61 0.0L1.65 6.26L1.65 17.79L12.05 24.0L21.56 18.18L19.74 16.8L12.37 21.39L12.32 15.25L10.52 16.21L10.5 20.77L4.63 17.17L22.35 6.36ZM3.57 7.42L10.23 11.53L3.6 15.57ZM11.68 2.51L18.31 6.63L12.1 10.37L5.47 6.51Z" fill="url(#lobe-icons-empiriolabs-fill)" fill-rule="evenodd" clip-rule="evenodd"/>
+</svg>


### PR DESCRIPTION
Adds an EmpirioLabs integration page (Model Provider) following the docs-only pattern of the SambaNova and Featherless AI pages: the EmpirioLabs API is OpenAI compatible, so the page shows `OpenAIChatGenerator` / `OpenAIGenerator` usage with `api_base_url=https://api.empiriolabs.ai/v1`, plus an `OpenAITextEmbedder` example (the API serves OpenAI-compatible embeddings natively). Frontmatter uses the haystack-ai pypi/repo per that precedent, and the logo SVG is included.