### PR TITLE
feat: add Whisper integration tile

### DIFF
--- a/integrations/openai.md
+++ b/integrations/openai.md
@@ -25,7 +25,7 @@ toc: true
 
 ## Overview
 
-You can use [OpenAI Models](https://openai.com/) in your Haystack pipelines with the [Generators](https://docs.haystack.deepset.ai/docs/generators), [Embedders](https://docs.haystack.deepset.ai/docs/embedders), [LocalWhisperTranscriber](https://docs.haystack.deepset.ai/docs/localwhispertranscriber) and [RemoteWhisperTranscriber](https://docs.haystack.deepset.ai/docs/remotewhispertranscriber).
+You can use [OpenAI Models](https://openai.com/) in your Haystack pipelines with the [Generators](https://docs.haystack.deepset.ai/docs/generators) and [Embedders](https://docs.haystack.deepset.ai/docs/embedders). Check out the [Whisper Integration](https://haystack.deepset.ai/integrations/whisper) for [LocalWhisperTranscriber](https://docs.haystack.deepset.ai/docs/localwhispertranscriber) and [RemoteWhisperTranscriber](https://docs.haystack.deepset.ai/docs/remotewhispertranscriber).
 
 ## Installation
 
@@ -120,33 +120,4 @@ print(res)
 
 ### Transcriber Models
 
-To use Whisper models from OpenAI, initialize a `LocalWhisperTranscriber` or `RemoteWhisperTranscriber` based on hosting options. To use Whisper locally, install it following the instructions on the Whisper [GitHub repo](https://github.com/openai/whisper). To use the OpenAI API, provide an API key. You can then use the suitable component to transcribe audio files.
-
-The Whisper transcribers live in the [`whisper-haystack`](https://haystack.deepset.ai/integrations/whisper) integration package. Below is the example of an indexing pipeline with `LocalWhisperTranscriber`. If you'd like to run the Whisper model locally, you need to install two additional packages:
-
-```bash
-pip install whisper-haystack
-pip install -U openai-whisper
-```
-
-```python
-from pathlib import Path
-from haystack import Pipeline
-from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
-from haystack.components.preprocessors import DocumentSplitter, DocumentCleaner
-from haystack.components.writers import DocumentWriter
-from haystack.document_stores.in_memory import InMemoryDocumentStore
-
-document_store = InMemoryDocumentStore()
-pipeline = Pipeline()
-pipeline.add_component(instance=LocalWhisperTranscriber(model="small"), name="transcriber")
-pipeline.add_component(instance=DocumentCleaner(), name="cleaner")
-pipeline.add_component(instance=DocumentSplitter(), name="splitter")
-pipeline.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
-
-pipeline.connect("transcriber.documents", "cleaner.documents")
-pipeline.connect("cleaner.documents", "splitter.documents")
-pipeline.connect("splitter.documents", "writer.documents")
-
-pipeline.run({"transcriber": {"audio_files": list(Path("path/to/audio/folder").iterdir())}})
-```
+To use Whisper models from OpenAI for audio transcription, see the [Whisper Integration](https://haystack.deepset.ai/integrations/whisper). It provides `LocalWhisperTranscriber` (runs Whisper on your machine) and `RemoteWhisperTranscriber` (uses the OpenAI Whisper API).

--- a/integrations/openai.md
+++ b/integrations/openai.md
@@ -122,17 +122,17 @@ print(res)
 
 To use Whisper models from OpenAI, initialize a `LocalWhisperTranscriber` or `RemoteWhisperTranscriber` based on hosting options. To use Whisper locally, install it following the instructions on the Whisper [GitHub repo](https://github.com/openai/whisper). To use the OpenAI API, provide an API key. You can then use the suitable component to transcribe audio files.
 
-Below is the example of indexing pipeline with `LocalWhisperTranscriber`. If you'd like to run the Whisper model locally, you need to install two additional packages:
+The Whisper transcribers live in the [`whisper-haystack`](https://haystack.deepset.ai/integrations/whisper) integration package. Below is the example of an indexing pipeline with `LocalWhisperTranscriber`. If you'd like to run the Whisper model locally, you need to install two additional packages:
 
 ```bash
-pip install transformers[torch]
+pip install whisper-haystack
 pip install -U openai-whisper
 ```
 
 ```python
 from pathlib import Path
 from haystack import Pipeline
-from haystack.components.audio import LocalWhisperTranscriber
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
 from haystack.components.preprocessors import DocumentSplitter, DocumentCleaner
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores.in_memory import InMemoryDocumentStore

--- a/integrations/whisper.md
+++ b/integrations/whisper.md
@@ -10,7 +10,7 @@ authors:
         linkedin: https://www.linkedin.com/company/deepset-ai/
 pypi: https://pypi.org/project/whisper-haystack
 repo: https://github.com/deepset-ai/haystack-core-integrations
-type: Custom Component
+type: Model Provider
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues
 logo: /logos/openai.png
 version: Haystack 2.0
@@ -102,6 +102,30 @@ result = pipe.run(
     }
 )
 print(result["transcriber"]["documents"][0].content)
+```
+
+Alternatively, the pipeline below indexes audio files from a local folder using `LocalWhisperTranscriber`, `DocumentCleaner`, `DocumentSplitter`, and `DocumentWriter`:
+
+```python
+from pathlib import Path
+from haystack import Pipeline
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
+from haystack.components.preprocessors import DocumentSplitter, DocumentCleaner
+from haystack.components.writers import DocumentWriter
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+document_store = InMemoryDocumentStore()
+pipeline = Pipeline()
+pipeline.add_component(instance=LocalWhisperTranscriber(model="small"), name="transcriber")
+pipeline.add_component(instance=DocumentCleaner(), name="cleaner")
+pipeline.add_component(instance=DocumentSplitter(), name="splitter")
+pipeline.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
+
+pipeline.connect("transcriber.documents", "cleaner.documents")
+pipeline.connect("cleaner.documents", "splitter.documents")
+pipeline.connect("splitter.documents", "writer.documents")
+
+pipeline.run({"transcriber": {"audio_files": list(Path("path/to/audio/folder").iterdir())}})
 ```
 
 ## License

--- a/integrations/whisper.md
+++ b/integrations/whisper.md
@@ -1,0 +1,108 @@
+---
+layout: integration
+name: Whisper
+description: Transcribe audio files with OpenAI's Whisper, locally or via the OpenAI API
+authors:
+    - name: deepset
+      socials:
+        github: deepset-ai
+        twitter: deepset_ai
+        linkedin: https://www.linkedin.com/company/deepset-ai/
+pypi: https://pypi.org/project/whisper-haystack
+repo: https://github.com/deepset-ai/haystack-core-integrations
+type: Custom Component
+report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues
+version: Haystack 2.0
+toc: true
+---
+
+### **Table of Contents**
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+
+## Overview
+
+The `whisper-haystack` integration provides two components that transcribe audio files into Haystack documents using OpenAI's [Whisper](https://github.com/openai/whisper) model:
+
+- [`LocalWhisperTranscriber`](https://docs.haystack.deepset.ai/docs/localwhispertranscriber): runs Whisper on your own machine. The audio is never sent to a third party.
+- [`RemoteWhisperTranscriber`](https://docs.haystack.deepset.ai/docs/remotewhispertranscriber): transcribes audio with the OpenAI Whisper API (and other OpenAI-compatible providers).
+
+Both components are typically used as the first step of an indexing pipeline. They were previously part of Haystack core and now live in the `whisper-haystack` integration package, maintained in [haystack-core-integrations](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper).
+
+## Installation
+
+```bash
+pip install whisper-haystack
+```
+
+This is all you need for `RemoteWhisperTranscriber`, which uses the OpenAI Whisper API (set the `OPENAI_API_KEY` environment variable).
+
+To use `LocalWhisperTranscriber`, also install the optional `openai-whisper` dependency and make sure [`ffmpeg`](https://ffmpeg.org/) is available on your system:
+
+```bash
+pip install -U openai-whisper
+```
+
+## Usage
+
+### RemoteWhisperTranscriber
+
+`RemoteWhisperTranscriber` transcribes audio with the OpenAI Whisper API. Set your `OPENAI_API_KEY` and pass the audio sources to transcribe:
+
+```python
+import os
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
+
+os.environ["OPENAI_API_KEY"] = "your-api-key"
+
+transcriber = RemoteWhisperTranscriber()
+result = transcriber.run(sources=["path/to/audio/file.mp3"])
+
+print(result["documents"][0].content)
+```
+
+### LocalWhisperTranscriber
+
+`LocalWhisperTranscriber` runs the Whisper model on your machine. Choose a model size (for example `tiny`, `base`, or `small`) and transcribe your audio files:
+
+```python
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
+
+transcriber = LocalWhisperTranscriber(model="small")
+transcriber.warm_up()
+result = transcriber.run(sources=["path/to/audio/file.mp3"])
+
+print(result["documents"][0].content)
+```
+
+### In a pipeline
+
+The pipeline below fetches an audio file from a URL with `LinkContentFetcher` and transcribes it with `LocalWhisperTranscriber`:
+
+```python
+from haystack import Pipeline
+from haystack.components.fetchers import LinkContentFetcher
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
+
+pipe = Pipeline()
+pipe.add_component("fetcher", LinkContentFetcher())
+pipe.add_component("transcriber", LocalWhisperTranscriber(model="tiny"))
+pipe.connect("fetcher", "transcriber")
+
+result = pipe.run(
+    data={
+        "fetcher": {
+            "urls": [
+                "https://github.com/deepset-ai/haystack/raw/refs/heads/main/test/test_files/audio/MLK_Something_happening.mp3"
+            ]
+        }
+    }
+)
+print(result["transcriber"]["documents"][0].content)
+```
+
+## License
+
+`whisper-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/whisper.md
+++ b/integrations/whisper.md
@@ -12,6 +12,7 @@ pypi: https://pypi.org/project/whisper-haystack
 repo: https://github.com/deepset-ai/haystack-core-integrations
 type: Custom Component
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues
+logo: /logos/openai.png
 version: Haystack 2.0
 toc: true
 ---


### PR DESCRIPTION
This adds an integration tile for the new `whisper-haystack` package, which provides two components moved out of Haystack core:

- `LocalWhisperTranscriber` (`haystack_integrations.components.audio.whisper`)
- `RemoteWhisperTranscriber` (`haystack_integrations.components.audio.whisper`)

It also updates the **OpenAI** tile's "Transcriber Models" section to install `whisper-haystack` and import from the new path.

Related PRs:
- haystack-core-integrations (new package): https://github.com/deepset-ai/haystack-core-integrations/pull/3468
- haystack main (deprecation): https://github.com/deepset-ai/haystack/pull/11685
- haystack v3 (removal): https://github.com/deepset-ai/haystack/pull/11686
- issue: https://github.com/deepset-ai/haystack-private/issues/367

Notes:
- The new whisper tile reuses `/logos/openai.png`.
- The component functionality in the examples was validated end-to-end against the `whisper-haystack` package (real OpenAI API + local `tiny` model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
