### PR TITLE
Use correct brand name EmpirioLabs AI

### DIFF
--- a/integrations/empiriolabs.md
+++ b/integrations/empiriolabs.md
@@ -1,6 +1,6 @@
 ---
 layout: integration
-name: EmpirioLabs
+name: EmpirioLabs AI
 description: Use open and proprietary models served by EmpirioLabs
 authors:
     - name: EmpirioLabs Team


### PR DESCRIPTION
Small follow-up to #514: the integration display name should be EmpirioLabs AI (the brand name), not EmpirioLabs. One-line change to the `name` field. Thank you!