### PR TITLE
docs(mcp): add a local stdio MCPToolset example using vestige-mcp-server

### DIFF
--- a/integrations/mcp.md
+++ b/integrations/mcp.md
@@ -160,6 +160,29 @@ In a nutshell, this example creates a pipeline that:
 
 This demonstrates how MCPTool can be seamlessly integrated into Haystack's agentic architecture, allowing LLMs to use external tools via the Model Context Protocol.
 
+### Example 4: Loading a local stdio memory server with MCPToolset
+
+The examples above run a stateless tool over stdio. The same `StdioServerInfo` path works with a stateful local server. This example loads all of the tools a memory server exposes at once using `MCPToolset`, and runs them through `ToolInvoker`. The server here is `vestige-mcp-server`, a local-first memory server published on npm, so no separate process or API key is needed and `npx` fetches it on first use.
+
+```python
+from haystack.components.tools import ToolInvoker
+
+from haystack_integrations.tools.mcp import MCPToolset, StdioServerInfo
+
+# Local-first MCP memory server, no API key, runs from npx
+toolset = MCPToolset(
+    server_info=StdioServerInfo(
+        command="npx",
+        args=["-y", "vestige-mcp-server"],
+    )
+)
+
+invoker = ToolInvoker(tools=list(toolset))
+# The toolset exposes the server's tools, for example search, memory, and codebase
+```
+
+`MCPToolset` discovers every tool the server advertises, so a single `StdioServerInfo` is enough to make all of them available to a pipeline or agent. This is useful for servers whose tools are meant to be used together rather than one at a time.
+
 ## License
 
 `mcp-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.


### PR DESCRIPTION
Hi deepset team. I maintain Vestige (github samvallad33), a local-first MCP memory server, and I have been running it through the existing mcp-haystack integration. The MCP page documents StdioServerInfo with uvx and the time server, and I wanted to add one more local-stdio example to the Usage section, this time loading a stateful server with MCPToolset rather than a single MCPTool, in case it is useful.

Nothing new is needed on the Haystack side. Vestige is a stdio MCP server published on npm, so MCPToolset reaches it the same way it reaches any other stdio server. The example loads the whole toolset and runs it through ToolInvoker, which felt like a nice complement to the single-tool examples already on the page.

For context: Vestige is a local-first cognitive memory MCP server for AI coding agents. FSRS-6 retention, prediction-error gating, active forgetting, spreading activation, 3D dashboard. Single Rust binary, npm install -g vestige-mcp-server. It is community-maintained by me and not affiliated with deepset.

I deliberately did not open a new integrations/vestige.md, since Vestige does not ship a vestige-haystack package yet and memory is already represented by mem0.md, so a standalone index entry would not match how the catalog is structured. If you would rather this example live in the Haystack docs instead of the index, or not at all, that is completely fine, just say so and I will close it. If a standalone catalog entry would be welcome down the line, I am happy to build a proper vestige-haystack wrapper package first so it follows the same pypi-backed pattern as everything else. Thanks for maintaining this.
