### PR TITLE
fix: link IBM DB2 logo

### DIFF
--- a/integrations/ibm-db-document-store.md
+++ b/integrations/ibm-db-document-store.md
@@ -10,6 +10,7 @@ authors:
 pypi: https://pypi.org/project/ibm-db-haystack/
 repo: https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/ibm_db
 type: Document Store
+logo: /logos/ibm-db2.png
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues
 version: Haystack 2.0
 toc: true

--- a/preview-build.sh
+++ b/preview-build.sh
@@ -11,7 +11,8 @@ git clone --depth=1 https://github.com/deepset-ai/haystack-home.git _site
 cd _site
 
 cp ../integrations/*.md content/integrations/
-cp -R ../logos/* static/logos/ 2>/dev/null || true
+mkdir -p static/logos
+cp -R ../logos/* static/logos/
 
 npm install
 


### PR DESCRIPTION
#542 introduced the integration page, but the logo was not linked properly