### PR TITLE
Update Voyage integration for Haystack 3.0 and add rerank + agent examples

### DIFF
--- a/integrations/voyage.md
+++ b/integrations/voyage.md
@@ -13,7 +13,7 @@ repo: https://github.com/awinml/voyage-embedders-haystack/tree/main
 type: Model Provider
 report_issue: https://github.com/awinml/voyage-embedders-haystack/issues
 logo: /logos/voyage_ai.jpg
-version: Haystack 2.0
+version: Haystack 3.0
 toc: true
 ---
 
@@ -26,6 +26,8 @@ toc: true
 - [Usage](#usage)
 - [Supported Models](#supported-models)
 - [Example](#example)
+- [Retrieve and Rerank](#retrieve-and-rerank)
+- [Use Voyage Search as an Agent Tool](#use-voyage-search-as-an-agent-tool)
 - [Contextualized Embeddings Example](#contextualized-embeddings-example)
 - [Multimodal Embeddings](#multimodal-embeddings)
 
@@ -62,6 +64,7 @@ For the complete list of available models, see the [Embeddings Documentation](ht
 
 | Model | Description |
 |-------|-------------|
+| `rerank-2.5` | Latest reranker model with the best accuracy |
 | `rerank-2` | High-accuracy reranker model |
 | `rerank-2-lite` | Efficient reranker with lower latency |
 
@@ -139,10 +142,10 @@ retriever = InMemoryEmbeddingRetriever(document_store=doc_store)
 doc_writer = DocumentWriter(document_store=doc_store)
 
 doc_embedder = VoyageDocumentEmbedder(
-    model="voyage-3.5",
+    model="voyage-4",
     input_type="document",
 )
-text_embedder = VoyageTextEmbedder(model="voyage-3.5", input_type="query")
+text_embedder = VoyageTextEmbedder(model="voyage-4", input_type="query")
 
 # Indexing Pipeline
 indexing_pipeline = Pipeline()
@@ -160,7 +163,7 @@ print(f"Embedding of first Document: {doc_store.filter_documents()[0].embedding}
 Query the Semantic Search Pipeline using the `InMemoryEmbeddingRetriever` and `VoyageTextEmbedder`:
 
 ```python
-text_embedder = VoyageTextEmbedder(model="voyage-3.5", input_type="query")
+text_embedder = VoyageTextEmbedder(model="voyage-4", input_type="query")
 
 # Query Pipeline
 query_pipeline = Pipeline()
@@ -175,6 +178,87 @@ results = query_pipeline.run({"TextEmbedder": {"text": "Which year did the Joker
 top_result = results["Retriever"]["documents"][0].content
 print("The top search result is:")
 print(top_result)
+```
+
+## Retrieve and Rerank
+
+Embedding retrieval is fast and cheap, but a reranker can meaningfully improve the order of the top results. The `VoyageRanker` re-scores the candidate documents returned by the retriever using Voyage AI's `rerank-2.5` model. Building on the `doc_store` and indexed corpus from the [Example](#example) above, add a `VoyageRanker` to the query pipeline:
+
+```python
+from haystack_integrations.components.rankers.voyage.ranker import VoyageRanker
+
+# Query pipeline: embed -> retrieve -> rerank
+rerank_pipeline = Pipeline()
+rerank_pipeline.add_component(instance=VoyageTextEmbedder(model="voyage-4", input_type="query"), name="TextEmbedder")
+rerank_pipeline.add_component(instance=InMemoryEmbeddingRetriever(document_store=doc_store, top_k=5), name="Retriever")
+rerank_pipeline.add_component(instance=VoyageRanker(model="rerank-2.5", top_k=3), name="Ranker")
+
+# Connect embedding -> retriever -> ranker
+rerank_pipeline.connect("TextEmbedder.embedding", "Retriever.query_embedding")
+rerank_pipeline.connect("Retriever.documents", "Ranker.documents")
+
+# VoyageTextEmbedder does not output `text`, so pass the query to both
+# the embedder and the ranker explicitly.
+query = "Which year did the Joker movie release?"
+results = rerank_pipeline.run({
+    "TextEmbedder": {"text": query},
+    "Ranker": {"query": query},
+})
+
+# Print the top 3 reranked results
+for i, doc in enumerate(results["Ranker"]["documents"]):
+    print(f"{i + 1}. score={doc.score:.4f} | {doc.content[:120]}")
+```
+
+## Use Voyage Search as an Agent Tool
+
+You can wrap the retrieve-and-rerank pipeline as a [Tool](https://docs.haystack.deepset.ai/docs/tools) and hand it to a Haystack [Agent](https://docs.haystack.deepset.ai/docs/agents). The Agent decides when to search the corpus and uses the retrieved passages to ground its answer.
+
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+from haystack.tools import Tool
+
+# Wrap the retrieve-and-rerank pipeline as a tool the Agent can call.
+def voyage_search(query: str) -> str:
+    res = rerank_pipeline.run({
+        "TextEmbedder": {"text": query},
+        "Ranker": {"query": query},
+    })
+    docs = res["Ranker"]["documents"]
+    return "\n\n".join(f"[{i + 1}] {doc.content}" for i, doc in enumerate(docs))
+
+search_tool = Tool(
+    name="voyage_search",
+    description="Search the indexed Wikipedia corpus for passages relevant to a query.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The search query to find relevant passages.",
+            },
+        },
+        "required": ["query"],
+    },
+    function=voyage_search,
+)
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+    tools=[search_tool],
+    system_prompt=(
+        "You are a helpful assistant. Use the voyage_search tool to find relevant passages "
+        "from Wikipedia, then answer the user's question based only on those passages. "
+        "If the search results don't contain the answer, say you couldn't find it."
+    ),
+)
+
+result = agent.run(
+    messages=[ChatMessage.from_user("Which year did the Joker movie release?")]
+)
+print(result["messages"][-1].text)
 ```
 
 ## Contextualized Embeddings Example
@@ -216,7 +300,7 @@ result = embedder.run(documents=docs)
 # the second chunk because it maintains its connection to "Apple Inc."
 ```
 
-For more examples, see the [contextualized embedder example](https://github.com/awinml/voyage-embedders-haystack/blob/voyage_context-3_model/examples/contextualized_embedder_example.py).
+For more examples, see the [contextualized embedder example](https://github.com/awinml/voyage-embedders-haystack/blob/main/examples/contextualized_embedder_example.py).
 
 ## Multimodal Embeddings
 

--- a/integrations/voyage.md
+++ b/integrations/voyage.md
@@ -212,37 +212,86 @@ for i, doc in enumerate(results["Ranker"]["documents"]):
 
 ## Use Voyage Search as an Agent Tool
 
-You can wrap the retrieve-and-rerank pipeline as a [Tool](https://docs.haystack.deepset.ai/docs/tools) and hand it to a Haystack [Agent](https://docs.haystack.deepset.ai/docs/agents). The Agent decides when to search the corpus and uses the retrieved passages to ground its answer.
+You can expose a Voyage-powered search pipeline as a tool for a Haystack `Agent`, which decides when to search the corpus and grounds its answer in the retrieved passages. The two examples below show this with a retrieve-and-rerank pipeline and with a lighter retrieve-only pipeline.
+
+### Retrieve and Rerank with `ComponentTool`
+
+Wrap the retrieve-and-rerank pipeline from above in a `SuperComponent`, then turn it into a tool with `ComponentTool`. The Agent calls the tool with a `query`, and the reranked passages are formatted back into text for the model:
 
 ```python
+from haystack import SuperComponent
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
-from haystack.tools import Tool
+from haystack.tools import ComponentTool
 
-# Wrap the retrieve-and-rerank pipeline as a tool the Agent can call.
-def voyage_search(query: str) -> str:
-    res = rerank_pipeline.run({
-        "TextEmbedder": {"text": query},
-        "Ranker": {"query": query},
-    })
-    docs = res["Ranker"]["documents"]
-    return "\n\n".join(f"[{i + 1}] {doc.content}" for i, doc in enumerate(docs))
+# Expose the retrieve-and-rerank pipeline as a single searchable component.
+# input_mapping sends the query to both the embedder and the ranker;
+# output_mapping surfaces the reranked documents.
+search_component = SuperComponent(
+    pipeline=rerank_pipeline,
+    input_mapping={"query": ["TextEmbedder.text", "Ranker.query"]},
+    output_mapping={"Ranker.documents": "documents"},
+)
 
-search_tool = Tool(
+# Format the retrieved documents into the text the Agent's LLM will read.
+def format_documents(documents):
+    return "\n\n".join(f"[{i + 1}] {doc.content}" for i, doc in enumerate(documents))
+
+# ComponentTool auto-generates the tool's JSON schema from the component inputs.
+search_tool = ComponentTool(
+    component=search_component,
     name="voyage_search",
     description="Search the indexed Wikipedia corpus for passages relevant to a query.",
-    parameters={
-        "type": "object",
-        "properties": {
-            "query": {
-                "type": "string",
-                "description": "The search query to find relevant passages.",
-            },
-        },
-        "required": ["query"],
-    },
-    function=voyage_search,
+    outputs_to_string={"source": "documents", "handler": format_documents},
+)
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+    tools=[search_tool],
+    system_prompt=(
+        "You are a helpful assistant. Use the voyage_search tool to find relevant passages "
+        "from Wikipedia, then answer the user's question based only on those passages. "
+        "If the search results don't contain the answer, say you couldn't find it."
+    ),
+)
+
+result = agent.run(
+    messages=[ChatMessage.from_user("Which year did the Joker movie release?")]
+)
+print(result["messages"][-1].text)
+```
+
+### Retrieve-only with `PipelineTool`
+
+If you don't need reranking, a plain embed-and-retrieve pipeline makes a lighter search tool. Here `PipelineTool` wraps the `Pipeline` directly. Building on the `doc_store` indexed in the [Example](#example) above:
+
+```python
+from haystack import Pipeline
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.dataclasses import ChatMessage
+from haystack.tools import PipelineTool
+
+# Query pipeline: embed -> retrieve (no reranker)
+search_pipeline = Pipeline()
+search_pipeline.add_component(instance=VoyageTextEmbedder(model="voyage-4", input_type="query"), name="TextEmbedder")
+search_pipeline.add_component(instance=InMemoryEmbeddingRetriever(document_store=doc_store, top_k=3), name="Retriever")
+search_pipeline.connect("TextEmbedder.embedding", "Retriever.query_embedding")
+
+# Format the retrieved documents into the text the Agent's LLM will read.
+def format_documents(documents):
+    return "\n\n".join(f"[{i + 1}] {doc.content}" for i, doc in enumerate(documents))
+
+# PipelineTool wraps the Pipeline directly - no SuperComponent needed.
+search_tool = PipelineTool(
+    pipeline=search_pipeline,
+    input_mapping={"query": ["TextEmbedder.text"]},
+    output_mapping={"Retriever.documents": "documents"},
+    name="voyage_search",
+    description="Search the indexed Wikipedia corpus for passages relevant to a query.",
+    outputs_to_string={"source": "documents", "handler": format_documents},
 )
 
 agent = Agent(


### PR DESCRIPTION
### Summary

Updates the Voyage AI integration page for Haystack 3.0 and adds two new examples that build on the existing semantic search pipeline.

### Changes

- Bumped `version` frontmatter from `Haystack 2.0` → `Haystack 3.0`
- Added `rerank-2.5` to the reranker model table
- Updated the semantic search example to use `voyage-4` (from `voyage-3.5`)
- **Retrieve and Rerank**: new section showing a `VoyageTextEmbedder → InMemoryEmbeddingRetriever → VoyageRanker(model="rerank-2.5")` query pipeline that re-scores the top retrieved documents
- **Use Voyage Search as an Agent Tool**: new section wrapping the retrieve-and-rerank pipeline as a Haystack `Tool` and handing it to an `Agent` with `OpenAIChatGenerator` so the agent can decide when to search and ground its answer in the retrieved passages
