### PR TITLE
Add Inspeximus document store integration

### DIFF
--- a/integrations/inspeximus.md
+++ b/integrations/inspeximus.md
@@ -1,0 +1,93 @@
+---
+layout: integration
+name: Inspeximus
+description: A persistent DocumentStore with a correction channel — supersede, revert, and receipted erasure
+authors:
+    - name: Inspeximus
+      socials:
+        github: DanceNitra
+pypi: https://pypi.org/project/inspeximus/
+repo: https://github.com/DanceNitra/inspeximus
+type: Document Store
+report_issue: https://github.com/DanceNitra/inspeximus/issues
+version: Haystack 2.0
+toc: true
+---
+### **Table of Contents**
+- [Overview](#overview)
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+
+## Overview
+
+[Inspeximus](https://github.com/DanceNitra/inspeximus) is an MIT-licensed, zero-dependency agent-memory
+library. `InspeximusDocumentStore` implements Haystack's `DocumentStore` protocol, so it slots into any
+Haystack pipeline the way `InMemoryDocumentStore` does — with two differences that matter for long-running
+or regulated systems:
+
+- **It persists.** The store is a file on disk; reopening it returns the same documents, rather than
+  starting empty each process.
+- **Its delete leaves nothing behind.** `delete_documents` removes the value from the bytes on disk, and
+  with receipts enabled it writes a signed, content-free tombstone — so a deletion made for a data-subject
+  request is provable, not merely done.
+
+It is a faithful drop-in: duplicate policies (`SKIP`, `OVERWRITE`, `NONE`, `FAIL`) behave exactly as they
+do in `InMemoryDocumentStore`, and filtering reuses Haystack's own `document_matches_filter`, so a
+`FilterRetriever` and pipeline serialization work unchanged. That parity is verified in CI, operation by
+operation, against `InMemoryDocumentStore`, with a falsification control that must fail.
+
+## Installation
+
+```bash
+pip install "inspeximus[haystack]"
+```
+
+## Usage
+
+### Components
+
+This integration provides one component:
+
+- `InspeximusDocumentStore`: a persistent `DocumentStore` you can pass to any store-agnostic retriever
+  (for example `FilterRetriever`) or to indexing components (`DocumentWriter`).
+
+### Write and retrieve
+
+```python
+from haystack import Pipeline
+from haystack.dataclasses import Document
+from haystack.components.retrievers import FilterRetriever
+from haystack.components.writers import DocumentWriter
+from inspeximus.integrations.haystack import InspeximusDocumentStore
+
+store = InspeximusDocumentStore(path="documents.json")
+
+# Index some documents.
+indexing = Pipeline()
+indexing.add_component("writer", DocumentWriter(document_store=store))
+indexing.run({"writer": {"documents": [
+    Document(content="the invoice is due in March", meta={"kind": "invoice"}),
+    Document(content="the manager is Rachel Tseng", meta={"kind": "person"}),
+]}})
+
+# Retrieve with a metadata filter.
+retrieval = Pipeline()
+retrieval.add_component("retriever", FilterRetriever(document_store=store))
+result = retrieval.run({"retriever": {
+    "filters": {"field": "meta.kind", "operator": "==", "value": "invoice"}
+}})
+print([d.content for d in result["retriever"]["documents"]])
+# ['the invoice is due in March']
+```
+
+### Provable erasure
+
+```python
+# Remove a document and get back the erasure record; with receipts enabled it is a signed tombstone.
+store.erase_documents(["<document-id>"], request_id="dsr-2026-04-01")
+```
+
+## License
+
+`inspeximus` is distributed under the MIT license.

--- a/integrations/inspeximus.md
+++ b/integrations/inspeximus.md
@@ -28,7 +28,7 @@ or regulated systems:
 
 - **It persists.** The store is a file on disk; reopening it returns the same documents, rather than
   starting empty each process.
-- **Its delete leaves nothing behind.** `delete_documents` removes the value from the bytes on disk, and
+- **Its erasure leaves nothing behind.** `erase_documents` removes the value from the bytes on disk, and
   with receipts enabled it writes a signed, content-free tombstone — so a deletion made for a data-subject
   request is provable, not merely done.
 


### PR DESCRIPTION
Adds a Document Store integration page for [Inspeximus](https://github.com/DanceNitra/inspeximus) (MIT, on PyPI as `inspeximus`).

`InspeximusDocumentStore` implements Haystack's `DocumentStore` protocol as a drop-in for `InMemoryDocumentStore`, with two differences that matter for long-running or regulated pipelines: it persists to a file, and its `delete_documents` removes the value from disk (with receipts enabled, leaving a signed, content-free tombstone so a deletion is provable).

It is a faithful drop-in — the duplicate policies (`SKIP`, `OVERWRITE`, `NONE`, `FAIL`) match `InMemoryDocumentStore` exactly (captured from the reference, not guessed), and filtering reuses Haystack's own `document_matches_filter`, so `FilterRetriever` and pipeline serialization work unchanged. Parity is verified in CI against `InMemoryDocumentStore`, operation by operation, with a falsification control that must fail.

The usage example in the page was run end to end against `haystack-ai 3.0.0` and `inspeximus 1.29.0`, and produces the output shown.

No logo included for now; happy to add one if you'd like it before merge.

This page was drafted with AI assistance; a human reviewed it and ran the example.
