### PR TITLE
docs: add discontinuation note to the Meta Llama API integration tile

### DIFF
--- a/integrations/meta_llama.md
+++ b/integrations/meta_llama.md
@@ -25,6 +25,12 @@ toc: true
 
 ## Overview
 
+🚧 **This integration is discontinued.**
+
+Meta is winding down the hosted Llama API (public preview) on **July 6, 2026** — after that date the service shuts down and API requests return a sunset response. Llama *models* remain available; only the hosted Llama API is being retired. The `meta-llama-haystack` integration has been archived (see [deepset-ai/haystack-core-integrations#3544](https://github.com/deepset-ai/haystack-core-integrations/issues/3544)).
+
+**You can keep using Meta Llama models with Haystack via other integrations**, for example [Ollama](https://haystack.deepset.ai/integrations/ollama), [Llama.cpp](https://haystack.deepset.ai/integrations/llama_cpp), [Hugging Face API](https://haystack.deepset.ai/integrations/huggingface-api), [Amazon Bedrock](https://haystack.deepset.ai/integrations/amazon-bedrock), or [Groq](https://haystack.deepset.ai/integrations/groq).
+
 This integration supports Meta Llama models provided through Meta’s own inferencing infrastructure. To get the `LLAMA_API_KEY`, check out [the Llama API website](https://llama.developer.meta.com?utm_source=partner-haystack&utm_medium=website).
 
 You can use Llama models with `MetaLlamaChatGenerator`.


### PR DESCRIPTION
## What

Adds a 🚧 discontinuation note to `integrations/meta_llama.md`: the hosted Llama API is being retired on July 6, 2026, and the `meta-llama-haystack` integration has been archived (code removal was merged in deepset-ai/haystack-core-integrations#3552).

The note follows the house style of the existing deprecation notice in `integrations/google-ai.md` and points users to live alternatives for running Llama models with Haystack (Ollama, Llama.cpp, Hugging Face API, Amazon Bedrock, Groq — all five links verified live).

## Why

This closes the remaining haystack-integrations checklist item of deepset-ai/haystack-core-integrations#3544 ("Add a note to the integration tile"). Credit to @julian-risch for the removal checklist and to @mittalpk for the status audit that flagged the two remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)