### PR TITLE
Clarify Arize integration positioning

### DIFF
--- a/integrations/arize-phoenix.md
+++ b/integrations/arize-phoenix.md
@@ -26,9 +26,11 @@ toc: true
 
 ## Overview
 
-**Arize Phoenix** is Arize's open-source platform that offers developers the quickest way to troubleshoot, evaluate, and experiment with LLM applications.
+**Arize Phoenix** is the open-source observability and evaluation platform from [Arize AI](https://arize.com/?utm_source=haystack-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrations-arize-phoenix). Use it to trace, evaluate, and experiment with LLM applications and AI agents in local, OSS, or self-hosted workflows.
 
-For a detailed integration guide, see the [documentation for Phoenix + Haystack](https://docs.arize.com/phoenix/tracing/integrations-tracing/haystack)
+For the full-featured production platform built for AI-native teams and enterprises, use [Arize AX](https://arize.com/products/ax/), available as managed cloud or enterprise self-hosted deployment. The Arize [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) cover how trace data becomes eval datasets, judge scores, and quality signals.
+
+For a detailed integration guide, see the [documentation for Phoenix + Haystack](https://arize.com/docs/phoenix/integrations/python/haystack/haystack-tracing).
 
 ## Installation
 
@@ -110,6 +112,6 @@ results = rag_pipeline.run(
 ## Resources
 
 - Check out the Phoenix [GitHub repository](https://github.com/Arize-ai/phoenix)
-- For an in-depth guide on how to host your own Phoenix instance, see the [Phoenix documentation](https://docs.arize.com/phoenix/deployment)
-- Try out free hosted Phoenix instances at [phoenix.arize.com](https://phoenix.arize.com/)
-- Check out the [Phoenix documentation](https://docs.arize.com/phoenix)
+- For an in-depth guide on how to host your own Phoenix instance, see the [Phoenix documentation](https://arize.com/docs/phoenix/deployment)
+- Learn more at [Arize Phoenix](https://arize.com/phoenix/)
+- Check out the [Phoenix documentation](https://arize.com/docs/phoenix)

--- a/integrations/arize.md
+++ b/integrations/arize.md
@@ -25,9 +25,11 @@ toc: true
 
 ## Overview
 
-Arize is AI Observability and Evaluation platform designed to help you troubleshoot, evaluate, and experiment on LLM and ML applications. Developers use Arize to get applications working quickly, evaluate performance, detect and prevent production issues, and curate datasets.
+[Arize AI](https://arize.com/?utm_source=haystack-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=integrations-arize) helps teams observe, evaluate, and improve LLM applications and AI agents. Use [Arize AX](https://arize.com/products/ax/) for the full-featured platform built for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment. Use [Arize Phoenix](https://arize.com/phoenix/) when you need an open-source workflow for local development, experimentation, or self-hosting.
 
-- [Documentation for Arize AI + Haystack](https://docs.arize.com/arize/large-language-models/tracing/auto-instrumentation/haystack)
+Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) show how traces can support debugging, evaluation, and continuous quality monitoring.
+
+- [Documentation for Arize AX + Haystack](https://arize.com/docs/ax/integrations/python-agent-frameworks/haystack/haystack-tracing)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Clarifies the Arize AX path and the Phoenix path across the Haystack integration pages
- Keeps the existing Haystack tracing examples intact
- Adds short context for readers moving from trace collection into evaluation workflows

## Why
The pages already show how to trace Haystack pipelines. This update makes it clearer that AX is the full-featured option for production, managed cloud, or enterprise self-hosted deployments, while Phoenix fits open-source local and self-hosted workflows.

## Testing
- Docs-only change; not run.
