### PR TITLE
Update integration references to align with PyPI package names

### DIFF
--- a/integrations/azure-ai-search.md
+++ b/integrations/azure-ai-search.md
@@ -8,7 +8,7 @@ authors:
         github: deepset-ai
         twitter: deepset_ai
         linkedin: https://www.linkedin.com/company/deepset-ai/
-pypi: https://pypi.org/project/azure-ai-search
+pypi: https://pypi.org/project/azure-ai-search-haystack
 repo: https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/azure-ai-search
 type: Document Store
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues

--- a/integrations/azure-cosmos-db.md
+++ b/integrations/azure-cosmos-db.md
@@ -32,7 +32,7 @@ version: Haystack 2.0
 
 ## Installation
 
-It's possible to connect to your **MongoDB** cluster on Azure Cosmos DB through the `MongoDBAtlasDocumentStore`. For that, install the `mongo-atlas-haystack` integration.
+It's possible to connect to your **MongoDB** cluster on Azure Cosmos DB through the `MongoDBAtlasDocumentStore`. For that, install the `mongodb-atlas-haystack` integration.
 ```bash
 pip install mongodb-atlas-haystack
 ```

--- a/integrations/brave.md
+++ b/integrations/brave.md
@@ -8,7 +8,7 @@ authors:
         github: deepset-ai
         twitter: deepset_ai
         linkedin: https://www.linkedin.com/company/deepset-ai/
-pypi: https://pypi.org/project/brave-search-haystack
+pypi: https://pypi.org/project/brave-haystack
 repo: https://github.com/deepset-ai/haystack-core-integrations
 type: Search & Extraction
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues
@@ -37,7 +37,7 @@ You need a Brave Search API key to use this integration. You can get one at [bra
 ## Installation
 
 ```bash
-pip install brave-search-haystack
+pip install brave-haystack
 ```
 
 ## Usage
@@ -132,4 +132,4 @@ asyncio.run(main())
 
 ### License
 
-`brave-search-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.
+`brave-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/integrations/chroma-documentstore.md
+++ b/integrations/chroma-documentstore.md
@@ -11,7 +11,7 @@ authors:
       github: deepset-ai
       twitter: deepset_ai
       linkedin: https://www.linkedin.com/company/deepset-ai/
-pypi: https://pypi.org/project/chroma-store
+pypi: https://pypi.org/project/chroma-haystack
 repo: https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/chroma
 type: Document Store
 report_issue: https://github.com/deepset-ai/haystack-core-integrations/issues

--- a/integrations/weights-and-bias-tracer.md
+++ b/integrations/weights-and-bias-tracer.md
@@ -92,4 +92,4 @@ the pipeline name you specified, when creating the `WeaveConnector`.
 
 ### License
 
-`weights_biases-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.
+`weave-haystack` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.


### PR DESCRIPTION
part of https://github.com/deepset-ai/haystack-private/issues/554

This PR updates the integration tiles of the following integrations to use the correct PyPI package name:
- Azure AI Search
- Azure CosmosDB
- Brave Search
- Chroma
- Weights & Biases Weave Tracer