### PR TITLE
Correct the Gandr free tier figure

### DIFF
--- a/integrations/gandr.md
+++ b/integrations/gandr.md
@@ -40,8 +40,7 @@ pip install gandr-haystack
 ## Usage
 
 Set `GANDR_API_KEY` in your environment. Keys start with `gnd_`, and a free key
-with 100,000 characters is available at [gandr.ai](https://gandr.ai) without a
-card.
+with 50,000 tokens is available at [gandr.ai](https://gandr.ai).
 
 ```python
 from gandr_haystack import GandrTTS


### PR DESCRIPTION
Corrects the free tier line on the Gandr integration page: the free key is 50,000 tokens (the unit is tokens, one token is one character), and drops the card sentence fragment. Matches the live pricing page at gandr.ai/pricing.

Disclosure: I work on Gandr.
