### PR TITLE
Add OpenZoo (Model Provider, OpenAI-compatible)

### DIFF
--- a/integrations/openzoo.md
+++ b/integrations/openzoo.md
@@ -31,8 +31,9 @@ Because the API is OpenAI-compatible, it works with Haystack's built-in
 `OpenAIGenerator` and `OpenAIChatGenerator` — no extra package is needed.
 
 The model catalog at `http://localhost:8402/v1/models` is free to fetch and
-includes per-model pricing and context metadata. Model ids are namespaced,
-e.g. `z-ai/glm-5.3-flash`.
+includes per-model pricing and context metadata. Model ids are bare model
+names, e.g. `claude-sonnet-5` or `gpt-4o-mini`; `auto` lets the proxy pick a
+model per request.
 
 ## Usage
 
@@ -57,7 +58,7 @@ from haystack.utils import Secret
 generator = OpenAIChatGenerator(
     api_key=Secret.from_token("sk-openzoo"),  # ignored by the proxy
     api_base_url="http://localhost:8402/v1",
-    model="z-ai/glm-5.3-flash",
+    model="auto",
 )
 
 response = generator.run(messages=[ChatMessage.from_user("Explain x402 in one sentence.")])

--- a/integrations/openzoo.md
+++ b/integrations/openzoo.md
@@ -1,0 +1,68 @@
+---
+layout: integration
+name: OpenZoo
+description: Use OpenZoo's signup-free, pay-per-call OpenAI-compatible API in Haystack
+authors:
+    - name: OpenZoo
+      socials:
+        github: staccDOTsol
+pypi: https://pypi.org/project/haystack-ai/
+repo: https://github.com/staccDOTsol/openzoo-mcp-server
+type: Model Provider
+report_issue: https://github.com/staccDOTsol/openzoo-mcp-server/issues
+version: Haystack 2.0
+toc: true
+---
+
+### **Table of Contents**
+
+- [Overview](#overview)
+- [Usage](#usage)
+
+## Overview
+
+[OpenZoo](https://openzoo.fun) is an OpenAI-compatible inference provider with
+no account or signup: any API key value is accepted, and usage is paid per
+request — by card, or automatically via the x402 protocol when running the
+local gateway (`npx openzoo`, serving `http://localhost:8402/v1`).
+
+Because the API is OpenAI-compatible, it works with Haystack's built-in
+`OpenAIGenerator` and `OpenAIChatGenerator` — no extra package is needed.
+
+The model catalog at
+[`https://api.openzoo.fun/v1/models`](https://api.openzoo.fun/v1/models) is
+free to fetch and includes per-model pricing and context metadata. Model ids
+are namespaced, e.g. `z-ai/glm-5.3-flash`.
+
+## Usage
+
+Install Haystack:
+
+```bash
+pip install haystack-ai
+```
+
+Use OpenZoo with `OpenAIChatGenerator` by pointing `api_base_url` at the
+endpoint. The API key can be any value (there is no signup):
+
+```python
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+from haystack.utils import Secret
+
+generator = OpenAIChatGenerator(
+    api_key=Secret.from_token("sk-openzoo"),  # any value works
+    api_base_url="https://api.openzoo.fun/v1",
+    model="z-ai/glm-5.3-flash",
+)
+
+response = generator.run(messages=[ChatMessage.from_user("Explain x402 in one sentence.")])
+print(response["replies"][0].text)
+```
+
+For a fully local setup, run `npx openzoo` and set
+`api_base_url="http://localhost:8402/v1"` — the gateway pays per call from a
+local burner wallet.
+
+Streaming works through the standard `streaming_callback` parameter, since the
+endpoint supports SSE.

--- a/integrations/openzoo.md
+++ b/integrations/openzoo.md
@@ -1,7 +1,7 @@
 ---
 layout: integration
 name: OpenZoo
-description: Use OpenZoo's signup-free, pay-per-call OpenAI-compatible API in Haystack
+description: Use OpenZoo's pay-per-call OpenAI-compatible API in Haystack via the local npx openzoo proxy
 authors:
     - name: OpenZoo
       socials:
@@ -22,28 +22,32 @@ toc: true
 ## Overview
 
 [OpenZoo](https://openzoo.fun) is an OpenAI-compatible inference provider with
-no account or signup: any API key value is accepted, and usage is paid per
-request — by card, or automatically via the x402 protocol when running the
-local gateway (`npx openzoo`, serving `http://localhost:8402/v1`).
+no account or signup: a small local proxy (`npx openzoo`, serving
+`http://localhost:8402/v1`) pays for each request via the x402 protocol from a
+local burner wallet. The proxy ignores the API key, so any non-empty value
+works.
 
 Because the API is OpenAI-compatible, it works with Haystack's built-in
 `OpenAIGenerator` and `OpenAIChatGenerator` — no extra package is needed.
 
-The model catalog at
-[`https://api.openzoo.fun/v1/models`](https://api.openzoo.fun/v1/models) is
-free to fetch and includes per-model pricing and context metadata. Model ids
-are namespaced, e.g. `z-ai/glm-5.3-flash`.
+The model catalog at `http://localhost:8402/v1/models` is free to fetch and
+includes per-model pricing and context metadata. Model ids are namespaced,
+e.g. `z-ai/glm-5.3-flash`.
 
 ## Usage
 
-Install Haystack:
+Install Haystack and start the OpenZoo proxy:
 
 ```bash
 pip install haystack-ai
+npx openzoo   # serves http://localhost:8402/v1
 ```
 
+`npx openzoo address` prints the proxy's wallet — fund it with USDC on Solana
+or Base; `npx openzoo balance` shows what is left.
+
 Use OpenZoo with `OpenAIChatGenerator` by pointing `api_base_url` at the
-endpoint. The API key can be any value (there is no signup):
+proxy. The API key can be any non-empty value (the proxy ignores it):
 
 ```python
 from haystack.components.generators.chat import OpenAIChatGenerator
@@ -51,8 +55,8 @@ from haystack.dataclasses import ChatMessage
 from haystack.utils import Secret
 
 generator = OpenAIChatGenerator(
-    api_key=Secret.from_token("sk-openzoo"),  # any value works
-    api_base_url="https://api.openzoo.fun/v1",
+    api_key=Secret.from_token("sk-openzoo"),  # ignored by the proxy
+    api_base_url="http://localhost:8402/v1",
     model="z-ai/glm-5.3-flash",
 )
 
@@ -60,9 +64,9 @@ response = generator.run(messages=[ChatMessage.from_user("Explain x402 in one se
 print(response["replies"][0].text)
 ```
 
-For a fully local setup, run `npx openzoo` and set
-`api_base_url="http://localhost:8402/v1"` — the gateway pays per call from a
-local burner wallet.
+The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless the
+caller pays x402 or presents an OpenZoo subscription key (`ozk_live_…`);
+Haystack cannot pay x402 itself, so use the local proxy.
 
 Streaming works through the standard `streaming_callback` parameter, since the
 endpoint supports SSE.


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

Adds an integration page for [OpenZoo](https://openzoo.fun), an OpenAI-compatible provider used through Haystack's built-in `OpenAIChatGenerator` with a custom `api_base_url` — the same no-extra-package shape as the existing Cerebras page.

What's distinctive (and why the example is trivially verifiable): there is no signup or real API key — the local `npx openzoo` proxy (`api_base_url="http://localhost:8402/v1"`) pays per call over x402 and ignores the `Secret.from_token` value — so the page's snippet runs as-is once the proxy is up. The hosted endpoint is mentioned only as needing x402 or a subscription key.

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
